### PR TITLE
Google Client Crash Fix

### DIFF
--- a/app/src/main/java/com/example/womenwhocode/womenwhocode/utils/LocationProvider.java
+++ b/app/src/main/java/com/example/womenwhocode/womenwhocode/utils/LocationProvider.java
@@ -102,9 +102,11 @@ public class LocationProvider implements
     }
 
     public void disconnect() {
-        if (mGoogleApiClient.isConnected()) {
-            LocationServices.FusedLocationApi.removeLocationUpdates(mGoogleApiClient, this);
-            mGoogleApiClient.disconnect();
+        if(mGoogleApiClient!=null) {
+            if (mGoogleApiClient.isConnected()) {
+                LocationServices.FusedLocationApi.removeLocationUpdates(mGoogleApiClient, this);
+                mGoogleApiClient.disconnect();
+            }
         }
     }
 


### PR DESCRIPTION
Fixed #332 .The api client is at times null which leads to unexpected crashes. The issue has been fixed.